### PR TITLE
This pull request implements a "show password" feature for both the login and register pages in our application. This enhancement improves user experience by allowing users to toggle the visibility of their passwords during input.

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,6 +12,7 @@ export default function Login() {
   const [password, setPassword] = useState<string>("");
   const [errors, setErrors] = useState({ email: "", password: "" });
   const [isLoading, setIsLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const auth = useAuth();
   const router = useRouter();
@@ -169,13 +170,22 @@ export default function Login() {
             <label htmlFor="password" className="text-left text-sm w-full">
               Password:
             </label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Password"
-              className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300"
-            />
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300 w-full"
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? "Hide" : "Show"}
+              </button>
+            </div>
             {errors.password && (
               <div className="text-red-500 dark:text-red-400 text-sm">
                 {errors.password}
@@ -183,7 +193,7 @@ export default function Login() {
             )}
           </div>
           <p className="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 underline font-medium text-right">
-            <Link href="/resetpassword">Forgot your pasword?</Link>
+            <Link href="/resetpassword">Forgot your password?</Link>
           </p>
           <button
             type="submit"

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -23,6 +23,8 @@ export default function Register() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [errors, setErrors] = useState({} as Errors);
   const [isLoading, setIsLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const auth = useAuth();
   const router = useRouter();
@@ -205,13 +207,22 @@ export default function Register() {
             <label htmlFor="password" className="text-left text-sm w-full">
               Password:
             </label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Password"
-              className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300"
-            />
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300 w-full"
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? "Hide" : "Show"}
+              </button>
+            </div>
             {errors.password && (
               <p className="text-red-500 dark:text-red-400 text-sm">{errors.password}</p>
             )}
@@ -223,13 +234,22 @@ export default function Register() {
             >
               Confirm Password:
             </label>
-            <input
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              placeholder="Confirm Password"
-              className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300"
-            />
+            <div className="relative">
+              <input
+                type={showConfirmPassword ? "text" : "password"}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Confirm Password"
+                className="bg-white dark:bg-gray-500 p-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-gray-500 dark:placeholder:text-gray-300 w-full"
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              >
+                {showConfirmPassword ? "Hide" : "Show"}
+              </button>
+            </div>
             {errors.confirmPassword && (
               <p className="text-red-500 dark:text-red-400 text-sm">{errors.confirmPassword}</p>
             )}


### PR DESCRIPTION
## Changes

1. **Login Page:**
   - Added a `showPassword` state variable to manage the visibility of the password.
   - Introduced a button to toggle the `showPassword` state.
   - Modified the password input field to conditionally change its type based on the `showPassword` state.

2. **Register Page:**
   - Added `showPassword` and `showConfirmPassword` state variables to manage the visibility of the password and confirm password fields.
   - Introduced buttons to toggle the `showPassword` and `showConfirmPassword` states.
   - Modified the password and confirm password input fields to conditionally change their types based on the respective state variables.

## Screenshots

*Include screenshots of the changes in the UI if possible*

## Testing

1. Verified that the password can be toggled between visible and hidden states on both the login and register pages.
2. Ensured that form validations still work correctly for both pages.
3. Tested the login and registration process to confirm that the show/hide password feature does not interfere with the functionality.

## Related Issues

*Link any related issues or tickets here*

## Additional Notes

- This feature aims to improve user experience, especially on mobile devices where mistyped passwords are common.
- Future improvements could include adding the same feature to other forms where password inputs are present.

Please review the changes and let me know if there are any issues or further enhancements needed.