### PR TITLE
Add 404 Error Header to NotFound Page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -24,6 +24,9 @@ export default function NotFound() {
           alt="logo"
         />
       </div>
+      <h2 className="mt-3 text-9xl font-black text-gray-800 dark:text-indigo-100">
+        404
+      </h2>
       <h2 className="my-3 text-3xl font-black text-gray-800 dark:text-indigo-100">
         OOPS! Page Not Found
       </h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,12 +907,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1896,9 +1896,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"


### PR DESCRIPTION
This pull request includes a small change to the `app/not-found.tsx` file. The change adds a new heading to display the "404" error code prominently.

* [`app/not-found.tsx`](diffhunk://#diff-fe77a89a1d202b09d5414068d5bb054cb4c597e8f5bd1e72f3e05adcaa9b09a4R27-R29): Added a new heading with class names for styling to display "404" above the existing "OOPS! Page Not Found" message.